### PR TITLE
add vega tooltip version

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-lite@5"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-lite-api@5.6.0"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vega-tooltip"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-tooltip@0.35.2"></script>
     <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>


### PR DESCRIPTION
vega tooltip redirects to a webpage without specifying the version now as the latest version must not be set up correctly upstream